### PR TITLE
EKF fuse odom0 of lidar/imu to odom1 of gps.

### DIFF
--- a/seaweed_localization/config/sim_localization_params.yaml
+++ b/seaweed_localization/config/sim_localization_params.yaml
@@ -1,3 +1,4 @@
+
 navsat_transform_node:
   ros__parameters:
     use_sim_time: true
@@ -29,28 +30,40 @@ ekf_filter_node:
     base_link_frame: wamv/base_link
     world_frame: odom
 
-    odom0: /odometry/gps
-    odom0_config: [true,  true,  false,   # x, y, z pos (GPS position for x,y)
-                   false, false, false,   # roll, pitch, yaw (yaw from IMU)
-                   false, false, false,   # x, y, z velo
-                   false, false, false,   # roll, pitch, yaw velo
-                   false, false, false]   # x, y, z accel
+    # Lidar SLAM / LIO provides high-rate local odometry (pose in odom -> base_link)
+    odom0: /dlio/odom_node/odom
+    odom0_config: [true,  true,  true,   # x, y, z pos (use x,y from lidar odom)
+            true, true, true,    # roll, pitch, yaw (use yaw from lidar odom)
+            true, true, true,   # x, y, z velo
+            true, true, true,   # roll, pitch, yaw velo
+            false, false, false]   # x, y, z accel
     odom0_differential: false
     odom0_relative: false
     odom0_queue_size: 10
 
+    # GPS-derived odometry (converted by navsat_transform_node) used as global correction
+    odom1: /odometry/gps
+    odom1_config: [true,  true,  false,   # x, y, z pos (GPS position for x,y)
+            false, false, false,   # roll, pitch, yaw (yaw from IMU)
+            false, false, false,   # x, y, z velo
+            false, false, false,   # roll, pitch, yaw velo
+            false, false, false]   # x, y, z accel
+    odom1_differential: false
+    odom1_relative: false
+    odom1_queue_size: 10
+
 
     # Note: Figure out if using odom roll/pitch w/ pcl or raw imu (leaning towards raw imu)
-    imu0: /wamv/sensors/imu/imu/data
-    imu0_config: [false, false, false,   # x, y, z pos
-                  false, false, true,    # roll, pitch, yaw
-                  false, false, false,   # x, y, z velo
-                  false, false, true,    # roll, pitch, yaw velo
-                  true,  true,  false]   # x, y, z accel (use x,y accelerometer readings)
-    imu0_differential: false
-    imu0_relative: false
-    imu0_queue_size: 10
-    imu0_remove_gravitational_acceleration: true
+    # imu0: /wamv/sensors/imu/imu/data
+    # imu0_config: [false, false, false,   # x, y, z pos
+    #               false, false, true,    # roll, pitch, yaw
+    #               false, false, false,   # x, y, z velo
+    #               false, false, true,    # roll, pitch, yaw velo
+    #               true,  true,  false]   # x, y, z accel (use x,y accelerometer readings)
+    # imu0_differential: false
+    # imu0_relative: false
+    # imu0_queue_size: 10
+    # imu0_remove_gravitational_acceleration: true
 
     use_control: false
 

--- a/seaweed_localization/config/sim_localization_params_dlio_lidar.yaml
+++ b/seaweed_localization/config/sim_localization_params_dlio_lidar.yaml
@@ -30,28 +30,40 @@ ekf_filter_node:
     base_link_frame: wamv/base_link
     world_frame: odom
 
-    odom0: /odometry/gps
-    odom0_config: [true,  true,  false,   # x, y, z pos (GPS position for x,y)
-                   false, false, false,   # roll, pitch, yaw (yaw from IMU)
-                   false, false, false,   # x, y, z velo
-                   false, false, false,   # roll, pitch, yaw velo
-                   false, false, false]   # x, y, z accel
+    # Lidar SLAM / LIO provides high-rate local odometry (pose in odom -> base_link)
+    odom0: /dlio/odom_node/odom
+    odom0_config: [true,  true,  true,   # x, y, z pos (use x,y from lidar odom)
+            true, true, true,    # roll, pitch, yaw (use yaw from lidar odom)
+            true, true, true,   # x, y, z velo
+            true, true, true,   # roll, pitch, yaw velo
+            false, false, false]   # x, y, z accel
     odom0_differential: false
     odom0_relative: false
     odom0_queue_size: 10
 
+    # GPS-derived odometry (converted by navsat_transform_node) used as global correction
+    odom1: /odometry/gps
+    odom1_config: [true,  true,  false,   # x, y, z pos (GPS position for x,y)
+            false, false, false,   # roll, pitch, yaw (yaw from IMU)
+            false, false, false,   # x, y, z velo
+            false, false, false,   # roll, pitch, yaw velo
+            false, false, false]   # x, y, z accel
+    odom1_differential: false
+    odom1_relative: false
+    odom1_queue_size: 10
+
 
     # Note: Figure out if using odom roll/pitch w/ pcl or raw imu (leaning towards raw imu)
-    imu0: /wamv/sensors/imu/imu/data
-    imu0_config: [false, false, false,   # x, y, z pos
-                  false, false, true,    # roll, pitch, yaw
-                  false, false, false,   # x, y, z velo
-                  false, false, true,    # roll, pitch, yaw velo
-                  true,  true,  false]   # x, y, z accel (use x,y accelerometer readings)
-    imu0_differential: false
-    imu0_relative: false
-    imu0_queue_size: 10
-    imu0_remove_gravitational_acceleration: true
+    # imu0: /wamv/sensors/imu/imu/data
+    # imu0_config: [false, false, false,   # x, y, z pos
+    #               false, false, true,    # roll, pitch, yaw
+    #               false, false, false,   # x, y, z velo
+    #               false, false, true,    # roll, pitch, yaw velo
+    #               true,  true,  false]   # x, y, z accel (use x,y accelerometer readings)
+    # imu0_differential: false
+    # imu0_relative: false
+    # imu0_queue_size: 10
+    # imu0_remove_gravitational_acceleration: true
 
     use_control: false
 

--- a/seaweed_localization/launch/sim_localization.launch.py
+++ b/seaweed_localization/launch/sim_localization.launch.py
@@ -9,8 +9,14 @@ from launch.conditions import IfCondition
 
 
 def launch_setup(context, *args, **kwargs):
+    use_lidar = LaunchConfiguration("lidar")
     localization_directory = get_package_share_directory("seaweed_localization")
     sim_localization_params = os.path.join(localization_directory, "config", "sim_localization_params.yaml")
+    if use_lidar in kwargs:
+        sim_localization_params = os.path.join(
+            localization_directory, "config", "sim_localization_params_dlio_lidar.yaml"
+        )
+        print("Using LIDAR localization parameters")
 
     # manually determined init point; turn into a ros param to pick between more worlds as needed
     world = "sydney_regatta"
@@ -86,6 +92,7 @@ def generate_launch_description():
     return LaunchDescription(
         [
             DeclareLaunchArgument("rviz", default_value="false", choices=["true", "false"]),
+            DeclareLaunchArgument("lidar", default_value="false", choices=["true", "false"]),
             OpaqueFunction(function=launch_setup),
         ]
     )


### PR DESCRIPTION
Fix #38 
- Remove imu fusion in ekf.
- take pose, pose vel, rotation and rotation vel from dlio lidar.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

# How Has This Been Tested?

Ran the `sim_localization.launch.py` on the rosbag data.
<img width="1439" height="476" alt="image" src="https://github.com/user-attachments/assets/75974cc9-1403-4084-91c2-e3c32546dcab" />



# Checklist:

- [x] No compilation/runtime issues
- [x] Updated necessary dependencies in respective `package.xml`
- [ ] Updated corresponding `README` docs to provide information to use new feature (specifically info about launch files & their params)
